### PR TITLE
Support format version 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [dependencies]
 xml-rs = "^ 0.8"
-petgraph = {git = "https://github.com/antonok-edm/petgraph", rev = "edges-undirected", version = "^ 0.5", default_features = false, features = ["graphmap"]}
+petgraph = {git = "https://github.com/antonok-edm/petgraph", branch = "edges-undirected", version = "^ 0.5", default_features = false, features = ["graphmap"]}
 adblock = "^ 0.2"
 url = "^ 2.1"
 addr = "^ 0.2"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -4,9 +4,25 @@ use petgraph::graphmap::DiGraphMap;
 
 use crate::types::{ NodeType, EdgeType };
 
+#[derive(Debug)]
+pub struct PageGraphDescriptor {
+    pub version: String,
+    pub about: String,
+    pub url: String,
+    pub is_root: bool,
+    pub time: PageGraphTime,
+}
+
+#[derive(Debug)]
+pub struct PageGraphTime {
+    pub start: u64,
+    pub end: u64,
+}
+
 /// The main PageGraph data structure.
 #[derive(Debug)]
 pub struct PageGraph {
+    pub desc: PageGraphDescriptor,
     pub edges: HashMap<EdgeId, Edge>,
     pub nodes: HashMap<NodeId, Node>,
     pub graph: DiGraphMap<NodeId, Vec<EdgeId>>,

--- a/src/graph_algos.rs
+++ b/src/graph_algos.rs
@@ -95,23 +95,7 @@ impl PageGraph {
 
     /// Gets the URL of the page the graph was recorded from
     pub fn root_url(&self) -> String {
-        let root_urls = self.nodes
-            .iter()
-            .filter(|(node_id, node)| {
-                if let NodeType::DomRoot { .. } = node.node_type {
-                    self.graph.edges_directed(*node_id.to_owned(), Direction::Incoming).count() == 0
-                } else {
-                    false
-                }
-            })
-            .map(|(_, node)| {
-                match &node.node_type {
-                    NodeType::DomRoot { url: Some(url), .. } => url,
-                    _ => panic!("Could not find DOM root URL"),
-                }
-            }).collect::<Vec<_>>();
-        assert_eq!(root_urls.len(), 1, "Could not determine root URL");
-        return root_urls[0].to_string();
+        return self.desc.url.to_string();
     }
 
     pub fn resource_request_types(&self, resource_node: &NodeId) -> Vec<String> {
@@ -162,7 +146,10 @@ impl PageGraph {
                             Err(_) => return false,
                         };
                         let request_url_scheme = request_url.scheme();
-                        let request_url_hostname = request_url.host_str().expect("Request URL has no host");
+                        let request_url_hostname = match request_url.host_str() {
+                            Some(host) => host,
+                            None => return false,
+                        };
                         let request_url_domain = get_domain(request_url_hostname);
 
                         let request_types = self.resource_request_types(id);
@@ -274,6 +261,7 @@ impl PageGraph {
             NodeType::TrackersShield {} => unimplemented!(),
             NodeType::JavascriptShield {} => unimplemented!(),
             NodeType::FingerprintingShield {} => unimplemented!(),
+            NodeType::FingerprintingV2Shield {} => unimplemented!(),
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -45,6 +45,7 @@ pub enum NodeType {
     TrackersShield {},
     JavascriptShield {},
     FingerprintingShield {},
+    FingerprintingV2Shield {},
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -98,13 +99,18 @@ pub enum EdgeType {
     },
     CreateNode {},
     JsResult { value: Option<String> },
-    JsCall { args: Option<String> },
+    JsCall {
+        args: Option<String>,
+        script_position: usize
+    },
     RequestComplete {
         resource_type: String,
         status: String,
-        value: String,
+        value: Option<String>,
         response_hash: Option<String>,
         request_id: usize,
+        headers: String,
+        size: String,
     },
     RequestError {
         status: String,


### PR DESCRIPTION
- Fully parses the new `desc` element
- Removes previous workarounds for boolean fields that were serialized as numbers
- Adds `fingerprintingV2 shield` node type
- Adds `script position` field to `js call`
- Adds `header` and `size` fields to `request complete`.