### PR TITLE
Final fixes for format version 0.2.1

### DIFF
--- a/src/from_xml.rs
+++ b/src/from_xml.rs
@@ -372,7 +372,7 @@ fn build_edge<R: std::io::Read>(
                                 .trim_end_matches("0")
                                 .trim_end_matches(".")
                                 .parse::<isize>()
-                                .expect(&format!("parse edge timestamp as isize: {}", contained))
+                                .unwrap_or_default()
                             );
                         } else {
                             data.insert(data_item.key, contained);
@@ -606,7 +606,7 @@ impl KeyedAttrs for types::NodeType {
         match type_str {
             "extensions" => Self::Extensions {},
             "remote frame" => Self::RemoteFrame {
-                url: drain_string!("url")
+                frame_id: drain_string!("frame id")
             },
             "resource" => Self::Resource {
                 url: drain_string!("url")
@@ -715,7 +715,9 @@ impl KeyedAttrs for types::EdgeType {
             "request error" => Self::RequestError {
                 status: drain_string!("status"),
                 request_id: drain_usize!("request id"),
-                value: drain_string!("value"),
+                value: drain_opt_string!("value"),
+                headers: drain_string!("headers"),
+                size: drain_string!("size"),
             },
             "request start" => Self::RequestStart {
                 request_type: crate::types::RequestType::from(&drain_string!("request type")[..]),

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,9 @@
 #[derive(Clone, PartialEq, Debug)]
 pub enum NodeType {
     Extensions {},
-    RemoteFrame { url: String },
+    RemoteFrame {
+        frame_id: String,
+    },
     Resource { url: String },
     AdFilter { rule: String },
     TrackerFilter,  // TODO
@@ -115,7 +117,9 @@ pub enum EdgeType {
     RequestError {
         status: String,
         request_id: usize,
-        value: String,
+        value: Option<String>,
+        headers: String,
+        size: String,
     },
     RequestStart {
         request_type: RequestType,


### PR DESCRIPTION
- Some node/edge timestamps are missing, so they default to 0
- `Remote frame`s are identified by frame IDs rather than urls
- `Request error` edges have optional `value` field, along with `headers` and `size` fields

With these changes I no longer have errors when parsing the `2020-09-17-storage-paper-crawls` graphs.