### PR TITLE
Support merging a remote frame into a root graph

### DIFF
--- a/src/from_xml.rs
+++ b/src/from_xml.rs
@@ -305,12 +305,7 @@ fn build_graph<R: std::io::Read>(parser: &mut EventReader<R>, key: &KeyModel, de
         }
     }
 
-    graph::PageGraph {
-        desc,
-        edges,
-        nodes,
-        graph,
-    }
+    graph::PageGraph::new(desc, edges, nodes, graph)
 }
 
 fn build_edge<R: std::io::Read>(
@@ -606,7 +601,7 @@ impl KeyedAttrs for types::NodeType {
         match type_str {
             "extensions" => Self::Extensions {},
             "remote frame" => Self::RemoteFrame {
-                frame_id: drain_string!("frame id")
+                frame_id: graph::FrameId::from(&drain_string!("frame id") as &str)
             },
             "resource" => Self::Resource {
                 url: drain_string!("url")

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,11 @@
+use crate::graph::FrameId;
+
 /// Represents the type of any PageGraph node, along with any associated type-specific data.
 #[derive(Clone, PartialEq, Debug)]
 pub enum NodeType {
     Extensions {},
     RemoteFrame {
-        frame_id: String,
+        frame_id: FrameId,
     },
     Resource { url: String },
     AdFilter { rule: String },


### PR DESCRIPTION
Edges and nodes in the remote frame graph are namespaced by the frame ID, then transferred over to the root graph. The corresponding `remote frame` node gets two new outgoing `cross DOM` edges added, to point to the top-level `DOM root` and `parser` nodes of the remote frame.