### PR TITLE
Change how ids for graph items are represented

### DIFF
--- a/examples/adblock-rules.rs
+++ b/examples/adblock-rules.rs
@@ -35,7 +35,7 @@ fn main() {
         matches!(&matching_element.node_type, NodeType::Resource { .. })
     }).map(|(node_id, resource_node)| {
         let requests = graph.incoming_edges(resource_node).filter_map(|edge| if let EdgeType::RequestStart { request_id, .. } = &edge.edge_type {
-            Some((*request_id, format!("{:?}", edge.id)))
+            Some((*request_id, format!("{}", edge.id)))
         } else {
             None
         }).collect::<Vec<_>>();
@@ -45,7 +45,7 @@ fn main() {
         if let NodeType::Resource { url } = &resource_node.node_type {
             MatchingResource {
                 url: url.clone(),
-                node_id: format!("{:?}", node_id),
+                node_id: format!("{}", node_id),
                 request_types,
                 requests,
             }

--- a/examples/downstream_requests.rs
+++ b/examples/downstream_requests.rs
@@ -1,13 +1,14 @@
 //! Prints out all downstream network requests of a given edge from the graph.
 
+use std::convert::TryFrom;
+
 use pagegraph::from_xml::read_from_file;
-use pagegraph::{graph::{EdgeId, FrameId}, types::EdgeType};
+use pagegraph::{graph::EdgeId, types::EdgeType};
 
 fn main() {
     let mut args = std::env::args().skip(1);
     let graph_file = args.next().expect("Provide a path to a `.graphml` file");
-    let id = args.next().expect("Provide an edge id, optionally followed by a frame id").parse::<usize>().expect("Edge id should be parseable as a number");
-    let frame_id = args.next().map(|frame_id_str| FrameId::from(frame_id_str.as_str()));
+    let edge_id = EdgeId::try_from(args.next().expect("Provide an edge id").as_str()).expect("Provided edge id was invalid");
 
     let mut graph = read_from_file(&graph_file);
 
@@ -22,14 +23,9 @@ fn main() {
         graph.merge_frame(frame_graph, &remote_frame_id);
     });
 
-    let mut edge_id: EdgeId = EdgeId::from(id);
-    if let Some(frame_id) = frame_id {
-        edge_id = edge_id.copy_for_frame_id(&frame_id)
-    }
-
     let downstream_effects = graph.all_downstream_effects_of(graph.edges.get(&edge_id).unwrap()).into_iter().filter_map(|edge| {
         if let EdgeType::RequestStart { request_id, .. } = edge.edge_type {
-            Some((format!("{:?}", edge.id), request_id))
+            Some((request_id, format!("{}", edge.id)))
         } else {
             None
         }

--- a/examples/request_id_info.rs
+++ b/examples/request_id_info.rs
@@ -1,5 +1,7 @@
 //! Prints out all info from the graph about the given request ID.
 
+use std::convert::TryFrom;
+
 use pagegraph::from_xml::read_from_file;
 use pagegraph::{graph::{Edge, FrameId, HasFrameId}, types::{EdgeType, NodeType, RequestType}};
 
@@ -35,7 +37,7 @@ fn main() {
     let mut args = std::env::args().skip(1);
     let graph_file = args.next().expect("Provide a path to a `.graphml` file");
     let id_arg = args.next().expect("Provide a request id, optionally followed by a frame id").parse::<usize>().expect("Edge id should be parseable as a number");
-    let frame_id = args.next().map(|frame_id_str| FrameId::from(frame_id_str.as_str()));
+    let frame_id = args.next().map(|frame_id_str| FrameId::try_from(frame_id_str.as_str()).expect("Frame id should be parseable"));
 
     let mut graph = read_from_file(&graph_file);
 

--- a/src/from_xml.rs
+++ b/src/from_xml.rs
@@ -100,7 +100,7 @@ fn build_desc<R: std::io::Read>(
         about: about.unwrap(),
         url: url.unwrap(),
         is_root: is_root.unwrap().parse::<bool>().unwrap(),
-        frame_id: frame_id.unwrap().as_str().into(),
+        frame_id: graph::FrameId::try_from(frame_id.unwrap().as_str()).unwrap(),
         time: time.unwrap(),
     }
 }
@@ -610,7 +610,7 @@ impl KeyedAttrs for types::NodeType {
         match type_str {
             "extensions" => Self::Extensions {},
             "remote frame" => Self::RemoteFrame {
-                frame_id: graph::FrameId::from(&drain_string!("frame id") as &str)
+                frame_id: graph::FrameId::try_from(&drain_string!("frame id") as &str).unwrap()
             },
             "resource" => Self::Resource {
                 url: drain_string!("url")

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::convert::TryFrom;
 
 use petgraph::graphmap::DiGraphMap;
 
@@ -107,6 +108,23 @@ impl From<usize> for GraphItemId {
     }
 }
 
+impl TryFrom<&str> for GraphItemId {
+    type Error = ParseIdError;
+
+    fn try_from(v: &str) -> Result<Self, Self::Error> {
+        if let Some((id, frame_id)) = v.split_once(':') {
+            let id = id.parse::<usize>()?;
+            Ok(GraphItemId {
+                id,
+                frame_id: Some(FrameId::try_from(frame_id)?),
+            })
+        } else {
+            let id = v.parse::<usize>()?;
+            Ok(Self::from(id))
+        }
+    }
+}
+
 impl GraphItemId {
     fn copy_for_frame_id(&self, frame_id: &FrameId) -> Self {
         Self {
@@ -146,6 +164,28 @@ impl HasFrameId for NodeId {
     }
 }
 
+impl std::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(frame_id) = self.get_frame_id() {
+            write!(f, "n{}:{}", self.0.id, frame_id)
+        } else {
+            write!(f, "n{}", self.0.id)
+        }
+    }
+}
+
+impl TryFrom<&str> for NodeId {
+    type Error = ParseIdError;
+
+    fn try_from(v: &str) -> Result<Self, Self::Error> {
+        if let Some(("", rest)) = v.split_once('n') {
+            Ok(Self(GraphItemId::try_from(rest)?))
+        } else {
+            Err(ParseIdError::MissingPrefix)
+        }
+    }
+}
+
 /// A node, representing a side effect of a page load.
 #[derive(Debug, Clone)]
 pub struct Node {
@@ -164,6 +204,31 @@ impl From<usize> for EdgeId {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseIdError {
+    MissingPrefix,
+    ParseIntError,
+    FrameIdLength,
+}
+
+impl From<std::num::ParseIntError> for ParseIdError {
+    fn from(_: std::num::ParseIntError) -> Self {
+        Self::ParseIntError
+    }
+}
+
+impl TryFrom<&str> for EdgeId {
+    type Error = ParseIdError;
+
+    fn try_from(v: &str) -> Result<Self, Self::Error> {
+        if let Some(("", rest)) = v.split_once('e') {
+            Ok(Self(GraphItemId::try_from(rest)?))
+        } else {
+            Err(ParseIdError::MissingPrefix)
+        }
+    }
+}
+
 impl EdgeId {
     pub fn copy_for_frame_id(&self, frame_id: &FrameId) -> Self {
         Self(self.0.copy_for_frame_id(frame_id))
@@ -173,6 +238,16 @@ impl EdgeId {
 impl HasFrameId for EdgeId {
     fn get_frame_id(&self) -> Option<FrameId> {
         self.0.frame_id
+    }
+}
+
+impl std::fmt::Display for EdgeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(frame_id) = self.get_frame_id() {
+            write!(f, "e{}:{}", self.0.id, frame_id)
+        } else {
+            write!(f, "e{}", self.0.id)
+        }
     }
 }
 
@@ -195,11 +270,14 @@ impl PartialEq for Edge {
 #[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
 pub struct FrameId(u128);
 
-impl From<&str> for FrameId {
+impl TryFrom<&str> for FrameId {
+    type Error = ParseIdError;
     /// Chromium formats these 128-bit tokens as 32-character hexadecimal strings.
-    fn from(v: &str) -> Self {
-        assert_eq!(v.len(), 32);
-        Self(u128::from_str_radix(v, 16).unwrap_or_else(|_| panic!("{} is an incorrectly formatted frame id", v)))
+    fn try_from(v: &str) -> Result<Self, Self::Error> {
+        if v.len() != 32 {
+            return Err(ParseIdError::FrameIdLength);
+        }
+        Ok(Self(u128::from_str_radix(v, 16)?))
     }
 }
 
@@ -212,5 +290,116 @@ impl std::fmt::Display for FrameId {
 impl std::fmt::Debug for FrameId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "\"{:0>32X}\"", self.0)
+    }
+}
+
+#[cfg(test)]
+mod id_parsing_tests {
+    use super::*;
+
+    #[test]
+    fn test_frame_id_parsing() {
+        assert_eq!(FrameId::try_from("00000000000000000000000000000000"), Ok(FrameId(0)));
+        assert_eq!(FrameId::try_from("00000000000000000000000000000001"), Ok(FrameId(1)));
+        assert_eq!(FrameId::try_from("0000000000000000000000000000000f"), Ok(FrameId(15)));
+        assert_eq!(FrameId::try_from("FfFFFFFfFffFFFfFFFFfffFFFfFFFfff"), Ok(FrameId(u128::MAX)));
+
+        assert_eq!(FrameId::try_from(" 00000000000000000000000000000000"), Err(ParseIdError::FrameIdLength));
+        assert_eq!(FrameId::try_from(" 0000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(FrameId::try_from("0000000000000000000000000000000"), Err(ParseIdError::FrameIdLength));
+        assert_eq!(FrameId::try_from("000000000000000000000000000000000"), Err(ParseIdError::FrameIdLength));
+    }
+
+    #[test]
+    fn test_graph_item_id_parsing() {
+        assert_eq!(GraphItemId::try_from("0"), Ok(GraphItemId{ id: 0, frame_id: None }));
+        assert_eq!(GraphItemId::try_from("8"), Ok(GraphItemId{ id: 8, frame_id: None }));
+        assert_eq!(GraphItemId::try_from("200"), Ok(GraphItemId{ id: 200, frame_id: None }));
+        assert_eq!(GraphItemId::try_from("103810150"), Ok(GraphItemId{ id: 103810150, frame_id: None }));
+        assert_eq!(GraphItemId::try_from("0:00000000000000000000000000000000"), Ok(GraphItemId{ id: 0, frame_id: Some(FrameId(0)) }));
+        assert_eq!(GraphItemId::try_from("8:00000000000000000000000000000001"), Ok(GraphItemId{ id: 8, frame_id: Some(FrameId(1)) }));
+        assert_eq!(GraphItemId::try_from("200:0000000000000000000000000000000f"), Ok(GraphItemId{ id: 200, frame_id: Some(FrameId(15)) }));
+        assert_eq!(GraphItemId::try_from("103810150:FfFFFFFfFffFFFfFFFFfffFFFfFFFfff"), Ok(GraphItemId{ id: 103810150, frame_id: Some(FrameId(u128::MAX)) }));
+
+        assert_eq!(GraphItemId::try_from("38 : 00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(GraphItemId::try_from("f8:00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(GraphItemId::try_from(":00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(GraphItemId::try_from("0:0000000000000000000000000000000"), Err(ParseIdError::FrameIdLength));
+        assert_eq!(GraphItemId::try_from("0:000000000000000000000000000000000"), Err(ParseIdError::FrameIdLength));
+    }
+
+    #[test]
+    fn test_edge_id_parsing() {
+        assert_eq!(EdgeId::try_from("e0"), Ok(EdgeId(GraphItemId{ id: 0, frame_id: None })));
+        assert_eq!(EdgeId::try_from("e8"), Ok(EdgeId(GraphItemId{ id: 8, frame_id: None })));
+        assert_eq!(EdgeId::try_from("e200"), Ok(EdgeId(GraphItemId{ id: 200, frame_id: None })));
+        assert_eq!(EdgeId::try_from("e103810150"), Ok(EdgeId(GraphItemId{ id: 103810150, frame_id: None })));
+        assert_eq!(EdgeId::try_from("e0:00000000000000000000000000000000"), Ok(EdgeId(GraphItemId{ id: 0, frame_id: Some(FrameId(0)) })));
+        assert_eq!(EdgeId::try_from("e8:00000000000000000000000000000001"), Ok(EdgeId(GraphItemId{ id: 8, frame_id: Some(FrameId(1)) })));
+        assert_eq!(EdgeId::try_from("e200:0000000000000000000000000000000f"), Ok(EdgeId(GraphItemId{ id: 200, frame_id: Some(FrameId(15)) })));
+        assert_eq!(EdgeId::try_from("e103810150:FfFFFFFfFffFFFfFFFFfffFFFfFFFfff"), Ok(EdgeId(GraphItemId{ id: 103810150, frame_id: Some(FrameId(u128::MAX)) })));
+
+        assert_eq!(EdgeId::try_from("n0"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(EdgeId::try_from("8"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(EdgeId::try_from("e 200"), Err(ParseIdError::ParseIntError));
+        assert_eq!(EdgeId::try_from("e103810150:"), Err(ParseIdError::FrameIdLength));
+        assert_eq!(EdgeId::try_from("n0:00000000000000000000000000000000"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(EdgeId::try_from("0:00000000000000000000000000000000"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(EdgeId::try_from("0e:00000000000000000000000000000000"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(EdgeId::try_from("e:00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(EdgeId::try_from(":00000000000000000000000000000000"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(EdgeId::try_from("e38 : 00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(EdgeId::try_from("ef8:00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(EdgeId::try_from("e:00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(EdgeId::try_from("e0:0000000000000000000000000000000"), Err(ParseIdError::FrameIdLength));
+        assert_eq!(EdgeId::try_from("e0:000000000000000000000000000000000"), Err(ParseIdError::FrameIdLength));
+    }
+
+    #[test]
+    fn test_node_id_parsing() {
+        assert_eq!(NodeId::try_from("n0"), Ok(NodeId(GraphItemId{ id: 0, frame_id: None })));
+        assert_eq!(NodeId::try_from("n8"), Ok(NodeId(GraphItemId{ id: 8, frame_id: None })));
+        assert_eq!(NodeId::try_from("n200"), Ok(NodeId(GraphItemId{ id: 200, frame_id: None })));
+        assert_eq!(NodeId::try_from("n103810150"), Ok(NodeId(GraphItemId{ id: 103810150, frame_id: None })));
+        assert_eq!(NodeId::try_from("n0:00000000000000000000000000000000"), Ok(NodeId(GraphItemId{ id: 0, frame_id: Some(FrameId(0)) })));
+        assert_eq!(NodeId::try_from("n8:00000000000000000000000000000001"), Ok(NodeId(GraphItemId{ id: 8, frame_id: Some(FrameId(1)) })));
+        assert_eq!(NodeId::try_from("n200:0000000000000000000000000000000f"), Ok(NodeId(GraphItemId{ id: 200, frame_id: Some(FrameId(15)) })));
+        assert_eq!(NodeId::try_from("n103810150:FfFFFFFfFffFFFfFFFFfffFFFfFFFfff"), Ok(NodeId(GraphItemId{ id: 103810150, frame_id: Some(FrameId(u128::MAX)) })));
+
+        assert_eq!(NodeId::try_from("e0"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(NodeId::try_from("8"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(NodeId::try_from("n 200"), Err(ParseIdError::ParseIntError));
+        assert_eq!(NodeId::try_from("n103810150:"), Err(ParseIdError::FrameIdLength));
+        assert_eq!(NodeId::try_from("e0:00000000000000000000000000000000"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(NodeId::try_from("0:00000000000000000000000000000000"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(NodeId::try_from("0n:00000000000000000000000000000000"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(NodeId::try_from("n:00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(NodeId::try_from(":00000000000000000000000000000000"), Err(ParseIdError::MissingPrefix));
+        assert_eq!(NodeId::try_from("n38 : 00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(NodeId::try_from("nf8:00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(NodeId::try_from("n:00000000000000000000000000000000"), Err(ParseIdError::ParseIntError));
+        assert_eq!(NodeId::try_from("n0:0000000000000000000000000000000"), Err(ParseIdError::FrameIdLength));
+        assert_eq!(NodeId::try_from("n0:000000000000000000000000000000000"), Err(ParseIdError::FrameIdLength));
+    }
+
+    #[test]
+    fn test_round_trip() {
+        fn test_str(id_str: &str) {
+            assert_eq!(format!("{}", NodeId::try_from(id_str).unwrap()), id_str);
+
+            let node_id = NodeId::try_from(id_str).unwrap();
+
+            assert_eq!(NodeId::try_from(format!("{}", node_id).as_str()).unwrap(), node_id);
+        }
+
+        test_str("n0");
+        test_str("n8");
+        test_str("n200");
+        test_str("n103810150");
+        test_str("n0:00000000000000000000000000000000");
+        test_str("n8:00000000000000000000000000000001");
+        test_str("n200:0000000000000000000000000000000F");
+        test_str("n103810150:FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+        test_str("n99999:0123456789ABCDEF0123456789ABCDEF");
     }
 }


### PR DESCRIPTION
With this PR, identifiers for items in the graph now have a formalized string representation:
- `<prefix><item-id>`, e.g. `e102` or `n83`
- `<prefix><item-id>:<frame-id>`, e.g. `e19:A1AE1FAE7018445F81B05B1B488055DE` or `n6:FED9E5BD1BCF4145AE596D4E38F5365A`

`<prefix>` identifies the item as a node or edge, either `n` or `e`, respectively.
`<item-id>` identifies the item within a single graph file; it is a decimal number.
`<frame-id>` identifies the graph file the item is from; it is a 128-bit hexadecimal number (32 hex characters).

There are some tests to ensure that the identifiers are parsed and formatted as expected.