### PR TITLE
Modify downstream_requests to return nested instead of flat list

### DIFF
--- a/pagegraph-cli/src/downstream_requests.rs
+++ b/pagegraph-cli/src/downstream_requests.rs
@@ -1,16 +1,29 @@
 //! Prints out all downstream network requests of a given edge from the graph.
 
 use pagegraph::{graph::{EdgeId, PageGraph}, types::EdgeType};
+use pagegraph::graph::DownstreamRequests;
+use pagegraph::types::NodeType;
 
 pub fn main(graph: &PageGraph, edge_id: EdgeId) {
-
-    let downstream_effects = graph.all_downstream_effects_of(graph.edges.get(&edge_id).unwrap()).into_iter().filter_map(|edge| {
-        if let EdgeType::RequestStart { request_id, .. } = edge.edge_type {
-            Some((request_id, format!("{}", edge.id)))
-        } else {
-            None
-        }
-    }).collect::<Vec<_>>();
-
-    println!("{}", serde_json::to_string(&downstream_effects).unwrap());
+    let edge = graph.edges.get(&edge_id).unwrap();
+    let all_downstream_requests = graph
+        .all_downstream_requests_nested(graph.edges.get(&edge_id).unwrap());
+    let node = graph.target_node(edge);
+    let url = match &node.node_type {
+        NodeType::Resource { url } => url,
+        _ => unreachable!()
+    };
+    match &edge.edge_type {
+        EdgeType::RequestStart {request_id, request_type, ..} => {
+            let top_level = DownstreamRequests {
+                request_id: *request_id,
+                url: url.to_string(),
+                request_type: request_type.clone(),
+                node_id: node.id,
+                children: all_downstream_requests
+            };
+            println!("{}", serde_json::to_string(&top_level).unwrap());
+        },
+        _ => panic!("Edge is not a RequestStart!")
+    };
 }

--- a/pagegraph/src/graph.rs
+++ b/pagegraph/src/graph.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 
 use petgraph::graphmap::DiGraphMap;
 
-use crate::types::{ NodeType, EdgeType };
+use crate::types::{NodeType, EdgeType, RequestType};
 
 #[derive(Debug)]
 pub struct PageGraphDescriptor {
@@ -93,7 +93,7 @@ impl PageGraph {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, serde::Serialize)]
 struct GraphItemId {
     id: usize,
     frame_id: Option<FrameId>,
@@ -143,7 +143,7 @@ pub fn is_same_frame_context<A: HasFrameId, B: HasFrameId>(a: A, b: B) -> bool {
 }
 
 /// An identifier used to reference a node.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, serde::Serialize)]
 pub struct NodeId(GraphItemId);
 
 impl From<usize> for NodeId {
@@ -186,6 +186,16 @@ impl TryFrom<&str> for NodeId {
     }
 }
 
+/// Downstream requests tree
+#[derive(serde::Serialize)]
+pub struct DownstreamRequests {
+    pub request_id: usize,
+    pub url: String,
+    pub request_type: RequestType,
+    pub node_id: NodeId,
+    pub children: Vec<DownstreamRequests>,
+}
+
 /// A node, representing a side effect of a page load.
 #[derive(Debug, Clone)]
 pub struct Node {
@@ -195,7 +205,7 @@ pub struct Node {
 }
 
 /// An identifier used to reference an edge.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, serde::Serialize)]
 pub struct EdgeId(GraphItemId);
 
 impl From<usize> for EdgeId {
@@ -252,7 +262,7 @@ impl std::fmt::Display for EdgeId {
 }
 
 /// An edge, representing an action taken during page load.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Edge {
     pub id: EdgeId,
     pub edge_timestamp: Option<isize>,
@@ -267,7 +277,7 @@ impl PartialEq for Edge {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
+#[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, serde::Serialize)]
 pub struct FrameId(u128);
 
 impl TryFrom<&str> for FrameId {

--- a/pagegraph/src/types.rs
+++ b/pagegraph/src/types.rs
@@ -61,6 +61,7 @@ pub enum NodeType {
 }
 
 #[derive(Clone, PartialEq, Debug)]
+#[derive(serde::Serialize)]
 pub enum RequestType {
     Image,
     ScriptClassic,
@@ -96,6 +97,7 @@ impl RequestType {
 
 /// Represents the type of any PageGraph edge, along with any associated type-specific data.
 #[derive(Clone, PartialEq, Debug)]
+#[derive(serde::Serialize)]
 pub enum EdgeType {
     Filter {},
     Structure {},

--- a/test_pages/test-script-calls-script-calls-script/script1.js
+++ b/test_pages/test-script-calls-script-calls-script/script1.js
@@ -1,0 +1,9 @@
+window.onload = () => {
+    let myScript = document.createElement("script");
+    myScript.setAttribute("src", "script2.js");
+    document.body.appendChild(myScript);
+
+    let anotherScript = document.createElement("script"); 
+    anotherScript.setAttribute("src", "https://www.google-analytics.com/analytics.js");
+    document.body.appendChild(anotherScript);
+}

--- a/test_pages/test-script-calls-script-calls-script/script2.js
+++ b/test_pages/test-script-calls-script-calls-script/script2.js
@@ -1,0 +1,3 @@
+let myScript = document.createElement("script");
+myScript.setAttribute("src", "https://sc-static.net/scevent.min.js");
+document.body.appendChild(myScript);

--- a/test_pages/test-script-calls-script-calls-script/test-script-calls-script.html
+++ b/test_pages/test-script-calls-script-calls-script/test-script-calls-script.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <script src="script1.js"></script>
+    </head>
+    <body>
+        This is an HTML page that loads a script that in turn loads another script.
+    </body>
+</html>


### PR DESCRIPTION
Also add test files.

This is an example run on the test file (served from localhost using a Python webserver). The page loaded a script `script1.js` that created two script nodes with src `script2.js` and google analytics. `script2.js` further created another script node with src `scevent.min.js`. 
```
$ cargo run -- -f localhost/page_graph_C6415C01696E33EC5D58F22B78613DBF.0.graphml downstream_requests e73 | jq
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/pagegraph-cli -f localhost/page_graph_C6415C01696E33EC5D58F22B78613DBF.0.graphml downstream_requests e73`
{
  "request_id": 2,
  "url": "https://localhost:8000/script1.js",
  "request_type": "ScriptClassic",
  "node_id": {
    "id": 72,
    "frame_id": null
  },
  "children": [
    {
      "request_id": 5,
      "url": "https://www.google-analytics.com/analytics.js",
      "request_type": "ScriptClassic",
      "node_id": {
        "id": 102,
        "frame_id": null
      },
      "children": []
    },
    {
      "request_id": 4,
      "url": "https://localhost:8000/script2.js",
      "request_type": "ScriptClassic",
      "node_id": {
        "id": 97,
        "frame_id": null
      },
      "children": [
        {
          "request_id": 6,
          "url": "https://sc-static.net/scevent.min.js",
          "request_type": "ScriptClassic",
          "node_id": {
            "id": 111,
            "frame_id": null
          },
          "children": []
        }
      ]
    }
  ]
}
```