### PR TITLE
Get source for script when getting request info

### DIFF
--- a/test_pages/test-script-calls-script-calls-script/test-script-calls-script.html
+++ b/test_pages/test-script-calls-script-calls-script/test-script-calls-script.html
@@ -3,6 +3,7 @@
         <script src="script1.js"></script>
     </head>
     <body>
+        <img src="https://brave.com/static-assets/images/brave-logo.svg"/>
         This is an HTML page that loads a script that in turn loads another script.
     </body>
 </html>


### PR DESCRIPTION
Before:
```
{
  "request_type": "script",
  "url": "https://localhost:8000/script1.js",
  "resource_type": "script",
  "status": "complete",
  "value": null,
  "response_hash": "zQqyWpejJlzevaKEzh77DiirwMonPZh/To7wrhGspc0=",
  "headers": "raw-request:\"Sec-Fetch-Mode\" \"no-cors\"\nraw-request:\"Sec-Fetch-Site\" \"same-origin\"\nraw-request:\"Accept-Encoding\" \"gzip, deflate, br\"\nraw-request:\"Host\" \"localhost:8000\"\nraw-request:\"Accept-Language\" \"en-US,en;q=0.9\"\nraw-request:\"User-Agent\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 11_3_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36\"\nraw-request:\"Accept\" \"*/*\"\nraw-request:\"Referer\" \"http://localhost:8000/test-script-calls-script.html\"\nraw-request:\"Sec-Fetch-Dest\" \"script\"\nraw-request:\"Connection\" \"keep-alive\"\nraw-response:\"Date\" \"Fri, 14 May 2021 22:08:20 GMT\"\nraw-response:\"Last-Modified\" \"Fri, 14 May 2021 21:04:26 GMT\"\nraw-response:\"Server\" \"SimpleHTTP/0.6 Python/2.7.16\"\nraw-response:\"Content-Length\" \"168\"\nraw-response:\"Content-type\" \"application/javascript\"\n",
  "size": "168"
}
```

After:
```
{
  "request_type": "script",
  "url": "https://localhost:8000/script1.js",
  "resource_type": "script",
  "status": "complete",
  "source": "window.onload = () => {\n    let myScript = document.createElement(\"script\");\n    myScript.setAttribute(\"src\", \"script2.js\");\n    document.body.appendChild(myScript);\n}\n",
  "value": null,
  "response_hash": "zQqyWpejJlzevaKEzh77DiirwMonPZh/To7wrhGspc0=",
  "headers": "raw-request:\"Sec-Fetch-Mode\" \"no-cors\"\nraw-request:\"Sec-Fetch-Site\" \"same-origin\"\nraw-request:\"Accept-Encoding\" \"gzip, deflate, br\"\nraw-request:\"Host\" \"localhost:8000\"\nraw-request:\"Accept-Language\" \"en-US,en;q=0.9\"\nraw-request:\"User-Agent\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 11_3_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36\"\nraw-request:\"Accept\" \"*/*\"\nraw-request:\"Referer\" \"http://localhost:8000/test-script-calls-script.html\"\nraw-request:\"Sec-Fetch-Dest\" \"script\"\nraw-request:\"Connection\" \"keep-alive\"\nraw-response:\"Date\" \"Fri, 14 May 2021 22:08:20 GMT\"\nraw-response:\"Last-Modified\" \"Fri, 14 May 2021 21:04:26 GMT\"\nraw-response:\"Server\" \"SimpleHTTP/0.6 Python/2.7.16\"\nraw-response:\"Content-Length\" \"168\"\nraw-response:\"Content-type\" \"application/javascript\"\n",
  "size": "168"
}
```