### PR TITLE
Add --source option for request_id_info

### DIFF
--- a/pagegraph-cli/Cargo.toml
+++ b/pagegraph-cli/Cargo.toml
@@ -10,3 +10,4 @@ pagegraph = { path = "../pagegraph" }
 clap = "2.33"
 serde = { version = "^ 1.0", features = ["derive"] }
 serde_json = "^ 1.0"
+html-escape = "0.2.9"

--- a/pagegraph-cli/src/main.rs
+++ b/pagegraph-cli/src/main.rs
@@ -45,6 +45,12 @@ fn main() {
                 .takes_value(true)
                 .value_name("REQUEST")
                 .required(true))
+            .arg(Arg::with_name("source")
+                .help("Print just the escaped source")
+                .takes_value(false)
+                .short("s")
+                .long("source")
+                .required(false))
             .arg(Arg::with_name("frame_id")
                 .help("Optional frame id that the request id is associated with, defaults to the root frame")
                 .takes_value(true)
@@ -121,7 +127,8 @@ fn main() {
     } else if let Some(matches) = matches.subcommand_matches("request_id_info") {
         use std::convert::TryFrom;
         let request_id = matches.value_of("request_id").unwrap().parse::<usize>().expect("Request id should be parseable as a number");
+        let just_source = matches.is_present("source");
         let frame_id: Option<FrameId> = matches.value_of("frame_id").map(|frame_id_str| FrameId::try_from(frame_id_str).expect("Frame id should be parseable"));
-        request_id_info::main(&graph, request_id, frame_id);
+        request_id_info::main(&graph, request_id, frame_id, just_source);
     }
 }

--- a/pagegraph-cli/src/request_id_info.rs
+++ b/pagegraph-cli/src/request_id_info.rs
@@ -9,7 +9,7 @@ where S: serde::Serializer {
     serializer.serialize_str(request_type.as_str())
 }
 
-pub fn main(graph: &PageGraph, request_id_arg: usize, frame_id: Option<FrameId>) {
+pub fn main(graph: &PageGraph, request_id_arg: usize, frame_id: Option<FrameId>, just_source: bool) {
     #[derive(serde::Serialize)]
     struct RequestInfo {
         // RequestStart
@@ -99,5 +99,9 @@ pub fn main(graph: &PageGraph, request_id_arg: usize, frame_id: Option<FrameId>)
         unreachable!()
     };
 
-    println!("{}", serde_json::to_string(&request_info).unwrap());
+    if just_source {
+        println!("{}", html_escape::decode_html_entities(&request_info.source));
+    } else {
+        println!("{}", serde_json::to_string(&request_info).unwrap());
+    }
 }


### PR DESCRIPTION
- Use html_escape to decode the string

Example usage:
```
$ cargo run -- -f localhost/page_graph_8E9DAF62E895C15A8E3187146A3EDD65.0.graphml request_id_info 2 --source
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/pagegraph-cli -f localhost/page_graph_8E9DAF62E895C15A8E3187146A3EDD65.0.graphml request_id_info 2 --source`
window.onload = () => {
    let myScript = document.createElement("script");
    myScript.setAttribute("src", "https://sc-static.net/scevent.min.js");
    document.body.appendChild(myScript);

    console.log(navigator.userAgent);
    console.log(window.localStorage);
    console.log(window.performance);
}
```