### PR TITLE
Additions to make sugarcoating easier

### DIFF
--- a/pagegraph-cli/src/adblock_rules.rs
+++ b/pagegraph-cli/src/adblock_rules.rs
@@ -2,9 +2,27 @@
 
 use pagegraph::graph::PageGraph;
 use pagegraph::types::{EdgeType, NodeType};
+use std::fs::File;
+use std::io::{BufReader, BufRead};
 
-pub fn main(graph: &PageGraph, filter_rule: &str) {
-    let matching_elements = graph.resources_matching_filter(&filter_rule);
+pub fn main(graph: &PageGraph, filter_rule: Option<&str>, filter_list_path: Option<&str>) {
+    // Check which one is defined
+    let filter_rules = if let Some(rule) = filter_rule {
+        vec![rule.to_string()]
+    } else {
+        // open file
+        let file = File::open(filter_list_path
+            .expect("At least one of path_to_filterlist or filter_rule must be defined")).unwrap();
+        let reader = BufReader::new(file);
+        let rules: Vec<_> = reader.lines()
+            .map(|l| l.expect("Could not parse line"))
+            .collect();
+        rules
+    };
+    let mut matching_elements = vec![];
+    for filter_rule in &filter_rules {
+        matching_elements.extend(graph.resources_matching_filter(&filter_rule));
+    }
 
     #[derive(serde::Serialize)]
     struct MatchingResource {

--- a/pagegraph-cli/src/adblock_rules.rs
+++ b/pagegraph-cli/src/adblock_rules.rs
@@ -4,10 +4,7 @@ use pagegraph::graph::PageGraph;
 use pagegraph::types::{EdgeType, NodeType};
 
 pub fn main(graph: &PageGraph, filter_rules: Vec<String>) {
-    let mut matching_elements = vec![];
-    for filter_rule in &filter_rules {
-        matching_elements.extend(graph.resources_matching_filter(&filter_rule));
-    }
+    let matching_elements = graph.resources_matching_filters(filter_rules);
 
     #[derive(serde::Serialize)]
     struct MatchingResource {

--- a/pagegraph-cli/src/adblock_rules.rs
+++ b/pagegraph-cli/src/adblock_rules.rs
@@ -2,23 +2,8 @@
 
 use pagegraph::graph::PageGraph;
 use pagegraph::types::{EdgeType, NodeType};
-use std::fs::File;
-use std::io::{BufReader, BufRead};
 
-pub fn main(graph: &PageGraph, filter_rule: Option<&str>, filter_list_path: Option<&str>) {
-    // Check which one is defined
-    let filter_rules = if let Some(rule) = filter_rule {
-        vec![rule.to_string()]
-    } else {
-        // open file
-        let file = File::open(filter_list_path
-            .expect("At least one of path_to_filterlist or filter_rule must be defined")).unwrap();
-        let reader = BufReader::new(file);
-        let rules: Vec<_> = reader.lines()
-            .map(|l| l.expect("Could not parse line"))
-            .collect();
-        rules
-    };
+pub fn main(graph: &PageGraph, filter_rules: Vec<String>) {
     let mut matching_elements = vec![];
     for filter_rule in &filter_rules {
         matching_elements.extend(graph.resources_matching_filter(&filter_rule));

--- a/pagegraph-cli/src/downstream_requests.rs
+++ b/pagegraph-cli/src/downstream_requests.rs
@@ -2,10 +2,32 @@
 
 use pagegraph::{graph::{EdgeId, PageGraph}, types::EdgeType};
 use pagegraph::graph::DownstreamRequests;
-use pagegraph::types::NodeType;
+use pagegraph::types::{NodeType, RequestType};
+use std::collections::HashSet;
 
-pub fn main(graph: &PageGraph, edge_id: EdgeId) {
+pub fn main(graph: &PageGraph, edge_id: EdgeId, just_requests: bool) {
     let edge = graph.edges.get(&edge_id).unwrap();
+    if just_requests {
+        let mut request_ids = HashSet::new();
+        match &edge.edge_type {
+            EdgeType::RequestStart { request_id, .. } => {
+                request_ids.insert(request_id);
+            },
+            _ => panic!("Edge is not a RequestStart!")
+        };
+        graph.all_downstream_effects_of(graph.edges.get(&edge_id).unwrap())
+            .into_iter()
+            .for_each(|edge| {
+                if let EdgeType::RequestStart { request_id, request_type, .. } = &edge.edge_type {
+                    if let RequestType::ScriptClassic = request_type {
+                        // we only want scripts!
+                        request_ids.insert(&request_id);
+                    }
+                }
+            });
+        println!("{}", serde_json::to_string(&request_ids).unwrap());
+        return;
+    }
     let all_downstream_requests = graph
         .all_downstream_requests_nested(graph.edges.get(&edge_id).unwrap());
     let node = graph.target_node(edge);

--- a/pagegraph-cli/src/request_id_info.rs
+++ b/pagegraph-cli/src/request_id_info.rs
@@ -1,7 +1,6 @@
 //! Prints out all info from the graph about the given request ID.
 
 use pagegraph::{graph::{Edge, FrameId, HasFrameId, PageGraph}, types::{EdgeType, NodeType, RequestType}};
-use std::process;
 
 /// Custom serializer for `RequestType`, so that `RequestInfo` can hold it directly rather than a
 /// string representation.
@@ -75,7 +74,7 @@ pub fn main(graph: &PageGraph, request_id_arg: usize, frame_id: Option<FrameId>,
         if let EdgeType::RequestStart { request_type, .. } = &start_edge.edge_type {
             if let NodeType::Resource { url } = &start_target.node_type {
                 let source = match script_node {
-                    None => process::exit(1), // fail silently
+                    None => panic!("Request ID does not correspond to a script!"), // fail
                     Some(script_node) => {
                         if let NodeType::Script { source, .. } = &script_node.node_type {
                             source.clone()

--- a/pagegraph/src/graph.rs
+++ b/pagegraph/src/graph.rs
@@ -197,7 +197,7 @@ pub struct DownstreamRequests {
 }
 
 /// A node, representing a side effect of a page load.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Node {
     pub id: NodeId,
     pub node_timestamp: isize,

--- a/pagegraph/src/types.rs
+++ b/pagegraph/src/types.rs
@@ -1,7 +1,7 @@
 use crate::graph::FrameId;
 
 /// Represents the type of any PageGraph node, along with any associated type-specific data.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, serde::Serialize)]
 pub enum NodeType {
     Extensions {},
     RemoteFrame {


### PR DESCRIPTION
- Option to take in filterlist instead of just one rule (adblock_rules)
- Option to output just flat list of request IDs (downstream_requests)
- Fail silently if not script node (request_id_info)