### PR TITLE
Add flag to only match on exception patterns in adblock_rules

### DIFF
--- a/pagegraph-cli/src/adblock_rules.rs
+++ b/pagegraph-cli/src/adblock_rules.rs
@@ -3,8 +3,8 @@
 use pagegraph::graph::PageGraph;
 use pagegraph::types::{EdgeType, NodeType};
 
-pub fn main(graph: &PageGraph, filter_rules: Vec<String>) {
-    let matching_elements = graph.resources_matching_filters(filter_rules);
+pub fn main(graph: &PageGraph, filter_rules: Vec<String>, only_exceptions: bool) {
+    let matching_elements = graph.resources_matching_filters(filter_rules, only_exceptions);
 
     #[derive(serde::Serialize)]
     struct MatchingResource {

--- a/pagegraph-cli/src/main.rs
+++ b/pagegraph-cli/src/main.rs
@@ -39,7 +39,13 @@ fn main() {
                 .long("list")
                 .required_unless("filter_rule")
                 .help("Set path to filterlist file (newline-separated adblock rules) to use")
-                .takes_value(true)))
+                .takes_value(true))
+            .arg(Arg::with_name("match_only_exceptions")
+                .short("e")
+                .long("only-exceptions")
+                .help("Only match on exception rules")
+                .takes_value(false)
+                .required(false)))
         .subcommand(SubCommand::with_name("downstream_requests")
             .about("Find network requests initiated as a result of a given edge in the graph")
             .arg(Arg::with_name("requests")
@@ -135,6 +141,7 @@ fn main() {
     } else if let Some(matches) = matches.subcommand_matches("adblock_rules") {
         let rule = matches.value_of("filter_rule");
         let filterlist = matches.value_of("path_to_filterlist");
+        let only_exceptions = matches.is_present("match_only_exceptions");
         let filter_rules = if let Some(rule) = rule {
             vec![rule.to_string()]
         } else {
@@ -147,7 +154,7 @@ fn main() {
                 .collect();
             rules
         };
-        adblock_rules::main(&graph, filter_rules);
+        adblock_rules::main(&graph, filter_rules, only_exceptions);
     } else if let Some(matches) = matches.subcommand_matches("downstream_requests") {
         use std::convert::TryFrom;
         let just_requests = matches.is_present("requests");

--- a/pagegraph/src/graph_algos.rs
+++ b/pagegraph/src/graph_algos.rs
@@ -465,10 +465,13 @@ impl PageGraph {
                             Some(source_domain != request_url_domain)
                         };
                         let blocker_result = blocker
-                            .check_network_urls_with_hostnames(url, request_url_hostname,
-                                                               source_hostname,
-                                                               request_type,
-                                                               third_party);
+                            .check_network_urls_with_hostnames_subset(url,
+                                                                      request_url_hostname,
+                                                                      source_hostname,
+                                                                      request_type,
+                                                                      third_party,
+                                                                      false,
+                                                                      true);
                         if only_exceptions {
                             blocker_result.exception.is_some()
                         } else {

--- a/pagegraph/src/graph_algos.rs
+++ b/pagegraph/src/graph_algos.rs
@@ -433,7 +433,8 @@ impl PageGraph {
     }
 
     /// Get a collection of all Resource nodes whose requests match a set of adblock filter patterns.
-    pub fn resources_matching_filters(&self, patterns: Vec<String>) -> Vec<(NodeId, &Node)> {
+    /// Optionally, only match on exception patterns
+    pub fn resources_matching_filters(&self, patterns: Vec<String>, only_exceptions: bool) -> Vec<(NodeId, &Node)> {
         let source_url = self.root_url();
 
         let source_url = url::Url::parse(&source_url).expect("Could not parse source URL");
@@ -463,11 +464,16 @@ impl PageGraph {
                         } else {
                             Some(source_domain != request_url_domain)
                         };
-                        blocker
+                        let blocker_result = blocker
                             .check_network_urls_with_hostnames(url, request_url_hostname,
                                                                source_hostname,
                                                                request_type,
-                                                               third_party).matched
+                                                               third_party);
+                        if only_exceptions {
+                            blocker_result.exception.is_some()
+                        } else {
+                            blocker_result.matched
+                        }
                     }).any(|matched| matched)
                 }
                 _ => false
@@ -477,8 +483,9 @@ impl PageGraph {
     }
 
     /// Get a collection of all Resource nodes whose requests match a given adblock filter pattern.
-    pub fn resources_matching_filter(&self, pattern: &str) -> Vec<(NodeId, &Node)> {
-        return self.resources_matching_filters(vec![pattern.to_string()]);
+    /// Optionally, only match on exception patterns
+    pub fn resources_matching_filter(&self, pattern: &str, only_exceptions: bool) -> Vec<(NodeId, &Node)> {
+        return self.resources_matching_filters(vec![pattern.to_string()], only_exceptions);
     }
 
     pub fn direct_downstream_effects_of(&self, edge: &Edge) -> Vec<&Edge>{


### PR DESCRIPTION
We'd need this for the sugarcoat-pipeline. We want to match on scripts that we've added exception rules for, not scripts that are currently blocked by filter lists.