### PR TITLE
Print blocking_filter and exception_filter in adblock_rules

### DIFF
--- a/pagegraph-cli/src/adblock_rules.rs
+++ b/pagegraph-cli/src/adblock_rules.rs
@@ -1,39 +1,8 @@
 //! Given an adblock network rule, prints out the nodes for resources that match that rule.
 
 use pagegraph::graph::PageGraph;
-use pagegraph::types::{EdgeType, NodeType};
 
-pub fn main(graph: &PageGraph, filter_rules: Vec<String>, only_exceptions: bool) {
-    let matching_elements = graph.resources_matching_filters(filter_rules, only_exceptions);
-
-    #[derive(serde::Serialize)]
-    struct MatchingResource {
-        url: String,
-        node_id: String,
-        request_types: Vec<String>,
-        requests: Vec<(usize, String)>,
-    }
-
-    let matching_resources = matching_elements.iter().filter(|(_id, matching_element)| {
-        matches!(&matching_element.node_type, NodeType::Resource { .. })
-    }).map(|(node_id, resource_node)| {
-        let requests = graph.incoming_edges(resource_node).filter_map(|edge| if let EdgeType::RequestStart { request_id, .. } = &edge.edge_type {
-            Some((*request_id, format!("{}", edge.id)))
-        } else {
-            None
-        }).collect::<Vec<_>>();
-
-        let request_types = graph.resource_request_types(node_id).into_iter().map(|(ty, _)| ty).collect();
-
-        if let NodeType::Resource { url } = &resource_node.node_type {
-            MatchingResource {
-                url: url.clone(),
-                node_id: format!("{}", node_id),
-                request_types,
-                requests,
-            }
-        } else { unreachable!() }
-    }).collect::<Vec<_>>();
-
-    println!("{}", serde_json::to_string(&matching_resources).unwrap())
+pub fn main(graph: &PageGraph, filter_rules: Vec<String>) {
+    let matching_elements = graph.resources_matching_filters(graph, filter_rules);
+    println!("{}", serde_json::to_string(&matching_elements).unwrap())
 }

--- a/pagegraph-cli/src/main.rs
+++ b/pagegraph-cli/src/main.rs
@@ -39,13 +39,7 @@ fn main() {
                 .long("list")
                 .required_unless("filter_rule")
                 .help("Set path to filterlist file (newline-separated adblock rules) to use")
-                .takes_value(true))
-            .arg(Arg::with_name("match_only_exceptions")
-                .short("e")
-                .long("only-exceptions")
-                .help("Only match on exception rules")
-                .takes_value(false)
-                .required(false)))
+                .takes_value(true)))
         .subcommand(SubCommand::with_name("downstream_requests")
             .about("Find network requests initiated as a result of a given edge in the graph")
             .arg(Arg::with_name("requests")
@@ -141,7 +135,6 @@ fn main() {
     } else if let Some(matches) = matches.subcommand_matches("adblock_rules") {
         let rule = matches.value_of("filter_rule");
         let filterlist = matches.value_of("path_to_filterlist");
-        let only_exceptions = matches.is_present("match_only_exceptions");
         let filter_rules = if let Some(rule) = rule {
             vec![rule.to_string()]
         } else {
@@ -154,7 +147,7 @@ fn main() {
                 .collect();
             rules
         };
-        adblock_rules::main(&graph, filter_rules, only_exceptions);
+        adblock_rules::main(&graph, filter_rules);
     } else if let Some(matches) = matches.subcommand_matches("downstream_requests") {
         use std::convert::TryFrom;
         let just_requests = matches.is_present("requests");


### PR DESCRIPTION
Fix #20
Remove only_exceptions param

Instead of passing a special parameter that prints only exceptions in `adblock_rules`, this PR changes `resources_matching_filters()` to also return blocking filter and exception filter if they exist. 
Also improves output of `adblock_rules` to be more structured.

Example:
```bash
{
    url: 'https://localhost:8000/script1.js',
    node_id: 'n72',
    request_types: [ 'script' ],
    requests: [
      {
        request_id: 2,
        edge_id: 'e73',
        blocking_filter: '||localhost^',
        exception_filter: '@@||localhost^$script'
      }
    ]
  },
```

as opposed to 
```bash
{
    url: 'https://localhost:8000/script1.js',
    node_id: 'n72',
    request_types: [ 'script' ],
    requests: [ [ 2, 'e73' ] ]
  }
```